### PR TITLE
add first test for app client

### DIFF
--- a/app/app_client.py
+++ b/app/app_client.py
@@ -1,0 +1,6 @@
+class AppClient():
+    def __init__(self, bot_client):
+        self._bot_client = bot_client
+
+    def start(self):
+        self._bot_client.start()

--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
 from os import environ, path
 from dotenv import load_dotenv
 from app.discord_client import DiscordClient
-
+from app.app_client import AppClient
 
 if environ.get("BOT_ENV") == "development":
     basedir = path.dirname(__file__)
     load_dotenv(path.join(basedir, '.env.development'))
 
-
-client = DiscordClient(environ.get("DISCORD_BOT_SECRET_KEY"))
-client.run()
+discord_client = DiscordClient(environ.get("DISCORD_BOT_SECRET_KEY"))
+app = AppClient(discord_client)
+app.start()

--- a/tests/discord_app_test.py
+++ b/tests/discord_app_test.py
@@ -1,0 +1,9 @@
+from app.app_client import AppClient
+from stubs.discord_client_stub import DiscordClientStub
+
+
+def test_app_run_bot_client_on_start():
+    discord_client_stub = DiscordClientStub()
+    app = AppClient(discord_client_stub)
+    app.start()
+    assert discord_client_stub.is_start == True

--- a/tests/stubs/discord_client_stub.py
+++ b/tests/stubs/discord_client_stub.py
@@ -1,0 +1,6 @@
+class DiscordClientStub():
+    def __init__(self):
+        self.is_start = False
+
+    def start(self):
+        self.is_start = True


### PR DESCRIPTION
Voilà le premier test qui permet de tester en isolation l'application et vérifie que le client du bot est bien lancé lorsqu'on démarre l'application.
Procéder de cette manière permet d'avoir une classe concrète qui contient l'implémentation de discord.Client et une autre de test DiscordClientStub qui permet de s'en passer pour les tests et ne sert que de bouchon avec un avantage que l'on n'a pas besoin de connexion internet et une grande rapidité d'exécution des tests. La seule contrainte est bien évidemment que ces deux classes évoluent en miroir (le langage python n'étant pas statiquement typé).

Le but n'est pas de tester que le client du bot lance bien un bot sur le serveur à travers le réseau, car, ceci est garantie par la librairie, tester cette partie doit se faire dans des tests d'infra qui sont plus lents et ne sont pas voués à être lancés systématiquement pendant le développement.